### PR TITLE
Fix: fixed cover-img loading for Safari <3

### DIFF
--- a/src/components/Player/PlayerCover.js
+++ b/src/components/Player/PlayerCover.js
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useRef } from 'react';
 import cn from 'classnames';
 import './PlayerCover.css';
 import Spinner from './Spinner';
@@ -13,9 +13,13 @@ function PlayerCover({
 }) {
   const [isLoaded, setLoadState] = useState(false);
   const imageLink = image ? image : gag;
+  const imageRef = useRef();
 
-  useEffect(() => {
-    setLoadState(false);
+  useEffect(() => { 
+    /* в Safari изображения подгружаются в кеш, и грузятся из него так быстро, что useEffect срабатывает уже после подгрузки изображения, и всё ломает. Поэтому теперь это обернуто в if */
+    if (!imageRef.current.complete) {
+      setLoadState(false);
+    }
   }, [image])
   
   const handleLoad = () => {
@@ -25,6 +29,7 @@ function PlayerCover({
   return (
     <div className="cover-wrapper" style={style}>
       <img
+        ref={imageRef}
         src={imageLink}
         className={cn("cover", {"cover_visible": isLoaded})}
         onLoad={handleLoad}

--- a/src/db/tracks.js
+++ b/src/db/tracks.js
@@ -38,9 +38,9 @@ export const tracks = [
     theme: {
       color: '#fff',
       backgroundColor: 'blue',
-      backgroundImage: 'linear-gradient(to top, #f43b47 0%, #453a94 100%)',
+      backgroundImage: 'linear-gradient(15deg, #13547a 0%, #80d0c7 100%)',
     },
-    albumPicture: 'https://images.unsplash.com/photo-1525253604620-23ac591dbea0?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=802&q=80',
+    albumPicture: 'https://images.unsplash.com/photo-1565292334631-95d1dd9e2970?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=742&q=80',
   },
   {
     id: '№3',
@@ -53,9 +53,9 @@ export const tracks = [
     theme: {
       color: '#000',
       backgroundColor: 'white',
-      backgroundImage: 'linear-gradient(to right, #00dbde 0%, #fc00ff 100%)',
+      backgroundImage: 'linear-gradient(to top, #f43b47 0%, #453a94 100%)',
     },
-    albumPicture: 'https://images.unsplash.com/photo-1587532635449-61603976e580?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1789&q=80',
+    albumPicture: 'https://images.unsplash.com/photo-1470225620780-dba8ba36b745?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1500&q=80',
   },
   {
     id: '№4',
@@ -67,9 +67,9 @@ export const tracks = [
     theme: {
       color: '#8B0000',
       backgroundColor: '#98FB98',
-      backgroundImage: 'linear-gradient(-225deg, #2CD8D5 0%, #C5C1FF 56%, #FFBAC3 100%)',
+      backgroundImage: 'linear-gradient(to top, #3b41c5 0%, #a981bb 49%, #ffc8a9 100%)',
     },
-    albumPicture: 'https://images.unsplash.com/photo-1565292334631-95d1dd9e2970?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=742&q=80',
+    albumPicture: 'https://images.unsplash.com/photo-1525253604620-23ac591dbea0?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=802&q=80',
   },
   {
     id: '№5',
@@ -94,7 +94,7 @@ export const tracks = [
     theme: {
       color: '#191970',
       backgroundColor: '#B0E0E6',
-      backgroundImage: 'linear-gradient(-225deg, #69EACB 0%, #EACCF8 48%, #6654F1 100%)',
+      backgroundImage: 'linear-gradient(-45deg, #ffad66 0%, #ff6691 100%)',
     },
     albumPicture: 'https://images.unsplash.com/photo-1566097260929-4ba43aa78fce?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=668&q=80',
   },
@@ -127,9 +127,9 @@ export const tracks = [
     theme: {
       color: '#800000',
       backgroundColor: '#D3D3D3',
-      backgroundImage: 'linear-gradient(to top, #e8198b 0%, #c7eafd 100%)',
+      backgroundImage: 'linear-gradient(-225deg, #CBBACC 0%, #2580B3 100%)',
     },
-    albumPicture: 'https://images.unsplash.com/photo-1470225620780-dba8ba36b745?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1500&q=80',
+    albumPicture: 'https://images.unsplash.com/photo-1587532635449-61603976e580?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1789&q=80',
   },
   {
     id: '№7',
@@ -148,7 +148,7 @@ export const tracks = [
     theme: {
       color: '#800080',
       backgroundColor: '#708090',
-      backgroundImage: 'linear-gradient(to top, #3b41c5 0%, #a981bb 49%, #ffc8a9 100%)',
+      backgroundImage: 'linear-gradient(-225deg, #A8BFFF 0%, #884D80 100%)',
     },
     albumPicture: 'https://images.unsplash.com/photo-1459305272254-33a7d593a851?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1500&q=80',
   },


### PR DESCRIPTION
В сафари изображения подгружаются в кеш, и выгружаются из него так быстро, что useEffect срабатывал уже после замены обложки для песни. Добавила реф и обернула внутренности useEffect в if.