### PR TITLE
Feat: player extends after 3sec. as the page loads

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -1,5 +1,5 @@
 import './App.css';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useMediaQuery } from 'react-responsive'
 import Main from './Main';
 import Info from './Info';
@@ -13,14 +13,38 @@ function App() {
   const [isPlayerExtend, setPlayerState] = useState(false);
   const isMobile = useMediaQuery({ query: '(max-width: 480px)' });
   const isLandscape = useMediaQuery({ query: '(orientation:landscape) and (max-height: 600px)' });
+  const isDesktop = useMediaQuery({ query: '(min-width: 1024px)' });
   const onPlayerExtend = () => {
     setPlayerState(!isPlayerExtend);
   }
   const [currentTrack, setCurrentTrack] = useState(tracks[0]);
+  const [playerExtendTimer, setPlayerExtendTimer] = useState(0);
 
   function onSetCurrentTrack(track) {
     setCurrentTrack(track);
   }
+
+  /* Для десктопов: плеер выезжает через 3 секунды после загрузки страницы.
+  Для отключения закомментить этот useEffect и стейт isDesktop */
+  useEffect(() => {
+    if (isDesktop) {
+      setPlayerExtendTimer(
+        setTimeout(() => {
+          setPlayerState(true);
+        }, 3000)
+      );
+    }
+  }, [isDesktop]);
+
+  /* Для десктопов: плеер выезжает через 3 секунды после загрузки страницы.
+  Отменяем выезд, если пользователь успел за это время раскрыть и скрыть плеер. 
+  Для отключения закомментить этот useEffect и стейт playerExtendTimer */
+  useEffect(() => {
+    if (playerExtendTimer && isPlayerExtend) {
+      clearTimeout(playerExtendTimer);
+      setPlayerExtendTimer(0);
+    }
+  }, [isPlayerExtend, playerExtendTimer]);
 
   return (
     <div className="page">

--- a/src/components/Player/Player.js
+++ b/src/components/Player/Player.js
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useSpring, animated } from 'react-spring';
 import './Player.css';
 import PlayerController from './PlayerController';
@@ -38,6 +38,15 @@ function Player ({ isPlayerExtend, onPlayerExtend, style, currentTrack, onSetCur
   }
 
   const AnimatedPlayerCover = animated(PlayerCover);
+
+  /* Для десктопов: плеер выезжает через 3 секунды после загрузки страницы. 
+  Рисуем компонент обложки и кнопки "Клип" и "Релизы".
+  Для отключения закомментить этот useEffect */
+  useEffect(() => {
+    if (isPlayerExtend) {
+      setIsExtendElementsMounted(true);
+    }
+  }, [isPlayerExtend])
   
   return (
     <section className="player" style={style}>


### PR DESCRIPTION
тикет: https://www.notion.so/4795ae58bcb54edeaf34262d7f55a9a6
Плеер выезжает на десктопах (1024px+) через 3 секунды после загрузки страницы. 
Если пользователь успел за это время его открыть и закрыть, эффект отменяется.
Для отключения см. инструкцию в комментариях по коду.