### PR TITLE
fix: header links styles for small-height smartphones

### DIFF
--- a/src/components/Header.css
+++ b/src/components/Header.css
@@ -74,9 +74,20 @@
   }
 }
 
-@media screen and (max-width: 480px) {
+@media screen and (max-width: 480px) and (min-height: 551px) {
   .header__form-anchor-link-container {
     margin-bottom: 12px;
+  }
+
+  .header__form-anchor-link {
+    padding: 7px 14px;
+    font-size: 12px;
+  }
+}
+
+@media screen and (max-width: 480px) and (max-height: 550px) {
+  .header__form-anchor-link-container {
+    margin-bottom: 5px;
   }
 
   .header__form-anchor-link {

--- a/src/components/MarshakLink.css
+++ b/src/components/MarshakLink.css
@@ -35,11 +35,26 @@
 
 @media screen and (max-width: 768px) {
   .marshak__link-container {
-    margin: 0 0 8px 0;
+    margin-right: 0;
+    margin-bottom: 8px;
   }
 }
 
-@media screen and (max-width: 480px) {
+@media screen and (max-width: 480px) and (min-height: 551px) {
+  .marshak__link-container {
+    margin-bottom: 5px;
+  }
+
+  .marshak__link {
+    padding: 7px 14px;
+  }
+}
+
+@media screen and (max-width: 480px) and (max-height: 550px) {
+  .marshak__link-container {
+    margin-bottom: 4px;
+  }
+
   .marshak__link {
     padding: 7px 14px;
   }

--- a/src/components/StreamServiceLink.css
+++ b/src/components/StreamServiceLink.css
@@ -45,9 +45,19 @@
 }
 
 
-@media screen and (max-width: 480px) {
+@media screen and (max-width: 480px) and (min-height: 551px) {
   .stream-services__link-container {
     margin-bottom: 5px;
+  }
+
+  .stream-services__link {
+    padding: 7px 14px;
+  }
+}
+
+@media screen and (max-width: 480px) and (max-height: 550px) {
+  .stream-services__link-container {
+    margin-bottom: 4px;
   }
 
   .stream-services__link {


### PR DESCRIPTION
Поправила высоту ссылок в хедере для смартфонов с высотой экрана меньше 550px