### PR TITLE
styles: fix spinner height for small mobile

### DIFF
--- a/src/components/Player/Spinner.css
+++ b/src/components/Player/Spinner.css
@@ -9,14 +9,27 @@
 
 .spinner {
   width: 50%;
-	height: 50%;
-	clear: both;
-	margin: 20px auto;
-	border: 4px rgba(255, 255, 255, 0.25) solid;
-	border-top: 4px rgba(255, 255, 255, 1) solid;
-	border-radius: 50%;
-	-webkit-animation: rotation 1s infinite linear;
-	animation: rotation 1s infinite linear;
+  padding-bottom: 50%;
+  box-sizing: border-box;
+  position: relative;
+  transform: translate(-50%, -50%);
+  top: 50%;
+  left: 50%;
+}
+
+.spinner__content {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  clear: both;
+  border: 4px rgba(255, 255, 255, 0.25) solid;
+  border-top: 4px rgba(255, 255, 255, 1) solid;
+  border-radius: 50%;
+  box-sizing: border-box;
+  -webkit-animation: rotation 1s infinite linear;
+  animation: rotation 1s infinite linear;
 }
 
 .spinner_hidden {

--- a/src/components/Player/Spinner.js
+++ b/src/components/Player/Spinner.js
@@ -5,8 +5,10 @@ function Spinner ({ width='50%', height='50%', isImageLoaded }) {
   return (
     <div
       className={cn("spinner", {"spinner_hidden": isImageLoaded})}
-      style={{width, height}}
-    />
+      style={{width, paddingBottom: height}}
+    >
+      <div className="spinner__content" />
+    </div>
   )
 }
 


### PR DESCRIPTION
Исправлено искажение загрузочного спинера для обложки трека при маленьких высотах смартфонов (высота обложки становится в 2 раза меньше ширины, и спиннер превращался в эллипс)