### PR TITLE
refactor: replace track checkout trigger

### DIFF
--- a/src/components/Player/Player.js
+++ b/src/components/Player/Player.js
@@ -59,14 +59,6 @@ function Player ({ isPlayerExtend, onPlayerExtend, style, currentTrack, onSetCur
     // Возвращаем true, если трек -- последний в списке.
   }
 
-  // Триггер для запуска трека после переключения из состояния паузы
-  const [triggerTrackCheckout, toggleTrigger] = useState(false);
-
-  const handleTrackClick = (track) => {
-    onSetCurrentTrack(track);
-    toggleTrigger(!triggerTrackCheckout);
-  }
-
   const handlePlayerSwitcherClick = () => {
     setTextInfo(!isTextInfo);
   }
@@ -100,7 +92,6 @@ function Player ({ isPlayerExtend, onPlayerExtend, style, currentTrack, onSetCur
         onForwardClick={handleForwardClick}
         onBackwardClick={handleBackwardClick}
         onTrackEnd={handleTrackEnd}
-        trigger={triggerTrackCheckout}
       />
       <ExtendBtn
         isOpen={isPlayerExtend}
@@ -109,7 +100,7 @@ function Player ({ isPlayerExtend, onPlayerExtend, style, currentTrack, onSetCur
       {isPlayerExtend && 
         <PlayerInfoContainer
         isOpen={isPlayerExtend}
-        onTrackClick={handleTrackClick}
+        onTrackClick={onSetCurrentTrack}
         tracks={tracks}
         isTextInfo={isTextInfo}
         currentTrack={currentTrack}

--- a/src/components/Player/PlayerController.js
+++ b/src/components/Player/PlayerController.js
@@ -8,7 +8,7 @@ import ControlBtn from './ControlBtn';
 import BackwardBtn from './BackwardBtn';
 import ForwardBtn from './ForwardBtn';
 
-function PlayerController({ isPlayerExtend, isVideoModalOpened, track, onForwardClick, onBackwardClick, onTrackEnd, trigger }) {
+function PlayerController({ isPlayerExtend, isVideoModalOpened, track, onForwardClick, onBackwardClick, onTrackEnd }) {
   const trackRef = useRef();
   const audioPlayerRef = useRef();
 
@@ -20,7 +20,6 @@ function PlayerController({ isPlayerExtend, isVideoModalOpened, track, onForward
 
   const {
     isPlaying,
-    setPlaying,
     handlePlayClick,
     isLoaded,
     handleTimeUpdate,
@@ -30,28 +29,6 @@ function PlayerController({ isPlayerExtend, isVideoModalOpened, track, onForward
     curTime,
     duration
   } = useAudioPlayer(audioPlayerRef, track, onTrackEnd);
-  
-  // В функциях handleForwardClick и handleBackwardClick напрямую устанавливается 
-  // isPlaying в состояние true для того, чтобы при переключении трека, когда текущий трек на паузе,
-  // следующий запускался.
-  const handleForwardClick = () => {
-    onForwardClick();
-    setPlaying(true);
-  }
-
-  const handleBackwardClick = () => {
-    onBackwardClick();
-    setPlaying(true);
-  }
-
-  // Изначально использовался useEffect внутри useAudioPlayer, в зависимости от трека устанавливающий
-  // isPlaying в состояние true (см. состояние репозитория на момент коммита ecfc2e8), но это работало
-  // везде кроме iOS.
-  useEffect(() => {
-    setPlaying(true);
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [trigger]);
-
 
   /* Ставим на паузу трек в аудио-плеере, если открывается модальное окно с youtube-плеером */
   useEffect(() => {
@@ -74,12 +51,12 @@ function PlayerController({ isPlayerExtend, isVideoModalOpened, track, onForward
           <p>Ваш браузер не поддерживает HTML5 аудио.</p>
         </audio>
         <div className="player__controllers">
-          <BackwardBtn onBtnClick={handleBackwardClick} />
+          <BackwardBtn onBtnClick={onBackwardClick} />
           <ControlBtn
             isPlaying={isPlaying}
             onBtnClick={handlePlayClick}
           />
-          <ForwardBtn onBtnClick={handleForwardClick} />
+          <ForwardBtn onBtnClick={onForwardClick} />
         </div>
         <div className="player__song-container">
           <p

--- a/src/hooks/useAudioPlayer.js
+++ b/src/hooks/useAudioPlayer.js
@@ -5,7 +5,8 @@ import { useState, useEffect } from 'react';
 audioElementId -- (строка, например 'audio')
 track -- трек из списка песен, устанавливается в качестве зависимости 
         (useEffect при смене трека)
-onTrackEnd -- обработчик конца трека
+onTrackEnd -- обработчик конца трека (указывает, что делать: переключать
+        на следующий трек или нет)
 */
 function useAudioPlayer(audioPlayerRef, track, onTrackEnd) {
   const [isLoaded, setLoadedState] = useState(false);
@@ -40,11 +41,10 @@ function useAudioPlayer(audioPlayerRef, track, onTrackEnd) {
   const handleTimeUpdate = () => setCurTime(audioPlayerRef.current.currentTime);
 
   const handleTrackEnd = () => {
-    setDuration(audioPlayerRef.current.duration);
-    setCurTime(0);
     const isLastTrack = onTrackEnd();
     if (isLastTrack) {
       setPlaying(false);
+      setCurTime(0);
     }
   }
   
@@ -52,6 +52,7 @@ function useAudioPlayer(audioPlayerRef, track, onTrackEnd) {
     if (clickedTime && clickedTime !== curTime) {
       audioPlayerRef.current.currentTime = clickedTime;
       setClickedTime(null);
+      console.log(clickedTime)
     } 
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [clickedTime]);
@@ -59,11 +60,15 @@ function useAudioPlayer(audioPlayerRef, track, onTrackEnd) {
   useEffect(() => {
     setCurTime(0);
     setLoadedState(false);
+    setPlaying(true);
   }, [track]);
+
+  useEffect(() => {
+    setPlaying(false);
+  }, []);
 
   return {
     isPlaying,
-    setPlaying,
     handlePlayClick,
     isLoaded,
     handleTimeUpdate,


### PR DESCRIPTION
Добавила useEffect, устанавливающий стейт isPlaying при загрузке страницы, без него при отключенных в браузере настройках, запрещающих автовоспроизведение, первый трек запускался автоматически.
Убрала лишний триггер, активизирующийся при смене трека, и упаковала запуск трека при переключении в useEffect  внутри хука useAudioPlayer.